### PR TITLE
feat: 変数名にpが使われている際に警告を出力するCopを追加

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -704,6 +704,7 @@ require_relative 'rubocop/cop/style/yaml_file_read'
 require_relative 'rubocop/cop/style/yoda_condition'
 require_relative 'rubocop/cop/style/yoda_expression'
 require_relative 'rubocop/cop/style/zero_length_predicate'
+require_relative 'rubocop/cop/style/illegal_variable'
 
 require_relative 'rubocop/cop/security/compound_hash'
 require_relative 'rubocop/cop/security/eval'

--- a/lib/rubocop/cop/style/illegal_variable.rb
+++ b/lib/rubocop/cop/style/illegal_variable.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      class IllegalVariable < Base
+        include RangeHelp
+
+        MSG_DETECTED = "Not recommend using 'p' as a variable because it can be confused with the standard output function 'p'."
+
+        def on_new_investigation
+          start_p_lines = processed_source.tokens.filter_map.with_index do |token, i|
+            if token.type == :tIDENTIFIER && token.text == 'p'
+              next_token = processed_source.tokens[i + 1]
+              next_token.type == :tEQL && next_token.text == '=' && token.line
+            end
+          end
+
+          return if start_p_lines.size.zero?
+
+          missing_offense(processed_source, start_p_lines)
+        end
+
+        private
+
+        def missing_offense(processed_source, start_p_lines)
+          start_p_lines.each do |line|
+            range = source_range(processed_source.buffer, line, line)
+            add_offense(range, message: MSG_DETECTED)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
RuboCopのコードを読んで追加できそうだったので、試してみました。
動作確認はlocalの別のプロジェクトからGemfile経由でインストールして行いました。

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
